### PR TITLE
feat: allow setting `port` with `RequestHandler`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -512,6 +512,7 @@ declare namespace Manbo {
     disableLatencyCompensation?: boolean;
     domain?: string;
     https?: boolean;
+    port?: number;
     latencyThreshold?: number;
     ratelimiterOffset?: number;
     requestTimeout?: number;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -120,6 +120,7 @@ class Client extends EventEmitter {
      * @arg {Boolean} [options.rest.disableLatencyCompensation=false] Whether to disable the built-in latency compensator or not
      * @arg {String} [options.rest.domain="discord.com"] The domain to use for API requests
      * @arg {Boolean} [options.rest.https=true] Whether to make requests to the Discord API over HTTPS (true) or HTTP (false)
+     * @arg {Number} [options.rest.port] The port to use for API requests (if using custom)
      * @arg {Number} [options.rest.latencyThreshold=30000] The average request latency at which Eris will start emitting latency errors
      * @arg {Number} [options.rest.ratelimiterOffset=0] A number of milliseconds to offset the ratelimit timing calculations by
      * @arg {Number} [options.rest.requestTimeout=15000] A number of milliseconds before REST requests are considered timed out

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -176,7 +176,8 @@ class RequestHandler {
                         host: this.options.domain,
                         path: this.options.baseURL + finalURL,
                         headers: headers,
-                        agent: this.options.agent
+                        agent: this.options.agent,
+                        ...(this.options.port ? {port: this.options.port} : {})
                     });
                 } catch(err) {
                     cb();


### PR DESCRIPTION
For using custom agents when requesting to a discord, using a port makes you a lot easier and allows you to use other ports as you wanted.
This does not include any breaking changes or code refactors since port property isn't required normally and only used when neccessary.